### PR TITLE
Timebox require

### DIFF
--- a/src/client/components/Agenda/Agenda.html
+++ b/src/client/components/Agenda/Agenda.html
@@ -42,7 +42,7 @@
         <label class="label">&nbsp;</label>
         <button ref=create-button class="button is-primary"
           @click="createNewAgendaItem"
-          v-bind:disabled="newAgendaItem.name.length === 0"
+          v-bind:disabled="newAgendaItem.name.length === 0 || newAgendaItem.timebox === undefined"
           >Create</button>
         <button class="button is-danger" @click=cancelForm>Cancel</button>
       </div>

--- a/src/server/socket-hander.ts
+++ b/src/server/socket-hander.ts
@@ -201,6 +201,11 @@ export default async function connection(socket: Message.ServerSocket) {
       user: owner
     };
 
+    if (isNaN(agendaItem.timebox)) {
+      respond(400, { message: 'Timebox duration required' });
+      return;
+    }
+
     meeting.agenda.push(agendaItem);
     await updateMeeting(meeting);
     client.trackEvent({ name: 'New Agenda Item' });


### PR DESCRIPTION
Require entering a time on both the server side and client side. Essential for the MongoDB port, probably useful without it anyway.