### PR TITLE
Add "Negative" to temp check

### DIFF
--- a/src/client/components/TempCheck/TempCheck.html
+++ b/src/client/components/TempCheck/TempCheck.html
@@ -21,16 +21,6 @@
       </div>
     </span>
     <span class="reaction-container">
-      <p><strong>Following</strong></p>
-      <button title="Following" class="reaction-item button" @click="react('👀')">
-        👀 {{countReactions('👀')}}
-      </button>
-      <div class="floating hide" v-if="countReactions('👀') > 0">
-        <div class="arrow top right"></div>
-        <span>{{listNames('👀')}}</span>
-      </div>
-    </span>
-    <span class="reaction-container">
       <p><strong>Confused</strong></p>
       <button title="Confused" class="reaction-item button" @click="react('❓')">
         ❓ {{countReactions('❓')}}

--- a/src/client/components/TempCheck/TempCheck.html
+++ b/src/client/components/TempCheck/TempCheck.html
@@ -60,5 +60,15 @@
         <span>{{listNames('😕')}}</span>
       </div>
     </span>
+    <span class="reaction-container">
+      <p><strong>Negative</strong></p>
+      <button title="Negative" class="reaction-item button" @click="react('👎')">
+        👎 {{countReactions('👎')}}
+      </button>
+      <div class="floating hide" v-if="countReactions('👎') > 0">
+        <div class="arrow top right"></div>
+        <span>{{listNames('👎')}}</span>
+      </div>
+    </span>
   </div>
 </div>

--- a/src/shared/Reaction.ts
+++ b/src/shared/Reaction.ts
@@ -5,4 +5,4 @@ export default interface Reaction {
   user: User;
 }
 
-export type ReactionTypes = '❤️' | '👍' | '👀' | '🤷' | '😕' | '❓';
+export type ReactionTypes = '❤️' | '👍' | '🤷' | '😕' | '❓' | '👎';


### PR DESCRIPTION
The temperature check currently has:
- two positive reactions
- following, which means "I am curios to see how the committee feel, but I don't have a stance"
- confused, which means "I do not understand what this is about"
- unconvinced, which means "I do understand it, but I am not convinced by your motivation"

This PR adds an explicitly negative option. So far, delegates had to pick one between unconvinced and confused to mean negative, but adding an explicit negative option makes it easier to distinguish between "I don't care", "Useless, but not harmful" and "I don't think we should add this to the language". Having more than one negative types of voted lets delegate express their negative position without having to necessarily vote "the absolute worse option".

This PR also removes "Following", to avoid increasing the (already large) number of options. People that don't want to vote can just... not press any button.

"Negative" is not an alternative for explicitly withholding consensus, as we don't use temp checks as a vote.