### PR TITLE
🔥 remove 'done speaking' button

### DIFF
--- a/src/client/components/CurrentSpeaker/CurrentSpeaker.html
+++ b/src/client/components/CurrentSpeaker/CurrentSpeaker.html
@@ -3,10 +3,7 @@
   <div v-if='speaker'>
       <div class="data-block-data">{{formatUser(speaker.user)}}</div>
       <div class="data-block-details">{{speaker.topic}}</div>
-      <div v-if="isMe" id="current-speaker-controls">
-        <button @click=doneSpeaking :class="{ button: true, 'is-primary': true, 'is-loading': loading }">I'm Done Speaking</button>
-      </div>
-      <div v-if="!isMe && $root.isChair" id="current-speaker-chair-controls">
+      <div v-if="$root.isChair" id="current-speaker-chair-controls">
         <button @click=doneSpeaking :class="{ button: true, 'is-loading': loading }">Next Speaker</button>
       </div>
   </div>


### PR DESCRIPTION
rationale:

1. Race conditions where the speaker and the chair hit the button, resulting in the disappearance of the next queue item.
1. Premature clicking of the button by the speaker, which advances the queue to the next topic erroneously, while we remain on the previous topic.  This also results in people not being able to correctly use the `Discuss current topic` and `clarifying question` buttons, as they will appear under the new topic.